### PR TITLE
chore(ios): empty homepage prevents pod install

### DIFF
--- a/ios/RNAdvertisingId.podspec
+++ b/ios/RNAdvertisingId.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNAdvertisingId
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/applike/react-native-advertising-id"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
Hi @santiph can you have a look at this PR?

Upon updaring RN to `0.60+`, I receive this error on `pod install`
```
Fetching podspec for `RNAdvertisingId` from `../node_modules/react-native-advertising-id/ios`
[!] The `RNAdvertisingId` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.
```