### PR TITLE
Bump android build versions for newer react native

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,12 +13,11 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -44,5 +43,5 @@ allprojects {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.google.android.gms:play-services-ads:17.1.3'
+    implementation 'com.google.android.gms:play-services-ads:19.0.0'
 }


### PR DESCRIPTION
Hello!

When building a react-native `0.61.5` project with this lib included by `./gradlew assembleRelease` the build fails because this lib has too old android targets:

> 1 exception was raised by workers:
>   com.android.builder.internal.aapt.v2.Aapt2Exception: Android resource linking failed
>   error: resource android:style/TextAppearance.Material.Widget.Button.Borderless.Colored not found.
>   error: resource android:style/TextAppearance.Material.Widget.Button.Colored not found.

In this PR I matched the targets with the [current targets ](https://github.com/facebook/react-native/blob/v0.61.5/template/android/build.gradle) of the 0.61.5 version.

The `yarn android --variant=release` command works without this somehow, but the above mentioned `assembleRelease` gradle command does not!

The `buildToolsVersion` is not neccessary for react native libs I think, but if im wrong then it should be set to `28.0.3`.
