### PR TITLE
iOS 14+ support added for changes related to application tracking permission.

### DIFF
--- a/ios/RNAdvertisingId.swift
+++ b/ios/RNAdvertisingId.swift
@@ -40,7 +40,9 @@ class RNAdvertisingId: NSObject {
                 if (status == .authorized){
                     result(true);
                 }
-                result(false);
+                else {
+                    result(false);
+                }
             }
         }
         else {

--- a/ios/RNAdvertisingId.swift
+++ b/ios/RNAdvertisingId.swift
@@ -15,7 +15,7 @@ class RNAdvertisingId: NSObject {
         isAppTrackingEnabled(requestPermission: true){(isAdvertisingTrackingEnabled: Bool) -> Void in
             //use the image that was just retrieved
             let response: NSMutableDictionary = [
-                "isAppTrackingEnabled" : isAdvertisingTrackingEnabled,
+                "isLimitAdTrackingEnabled" : !isAdvertisingTrackingEnabled,
                 "advertisingId" : ""
             ]
             

--- a/ios/RNAdvertisingId.swift
+++ b/ios/RNAdvertisingId.swift
@@ -36,12 +36,14 @@ class RNAdvertisingId: NSObject {
             if(!requestPermission) {
                 result(ATTrackingManager.trackingAuthorizationStatus == .authorized);
             }
-            ATTrackingManager.requestTrackingAuthorization { status in
-                if (status == .authorized){
-                    result(true);
-                }
-                else {
-                    result(false);
+            else {
+                ATTrackingManager.requestTrackingAuthorization { status in
+                    if (status == .authorized){
+                        result(true);
+                    }
+                    else {
+                        result(false);
+                    }
                 }
             }
         }

--- a/ios/RNAdvertisingId.swift
+++ b/ios/RNAdvertisingId.swift
@@ -5,13 +5,14 @@
 //
 
 import AdSupport
+import AppTrackingTransparency
 //import Foundation
 
 @objc(RNAdvertisingId)
 class RNAdvertisingId: NSObject {
     @objc
-    func getAdvertisingId(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
-        let isAdvertisingTrackingEnabled : Bool = ASIdentifierManager.shared().isAdvertisingTrackingEnabled
+    func getAdvertisingId(_ requestPermission: Bool = false, resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        let isAdvertisingTrackingEnabled : Bool = isAppTrackingEnabled(requestPermission);
         
         let response: NSMutableDictionary = [
             "isLimitAdTrackingEnabled" : !isAdvertisingTrackingEnabled,
@@ -24,5 +25,20 @@ class RNAdvertisingId: NSObject {
         }
         
         resolve(response)
+    }
+
+    //NEWLY ADDED PERMISSIONS FOR iOS 14
+    func isAppTrackingEnabled(requestPermission: Bool = false) -> Bool{
+        if #available(iOS 14, *) {
+            if(!requestPermission) {
+                return (ATTrackingManager.trackingAuthorizationStatus == .authorized);
+            }
+            ATTrackingManager.requestTrackingAuthorization { status in
+                return (status == .authorized);
+            }
+        }
+        else {
+            return ASIdentifierManager.shared().isAdvertisingTrackingEnabled;
+        }
     }
 }

--- a/ios/RNAdvertisingId.swift
+++ b/ios/RNAdvertisingId.swift
@@ -40,6 +40,7 @@ class RNAdvertisingId: NSObject {
                 if (status == .authorized){
                     result(true);
                 }
+                result(false);
             }
         }
         else {


### PR DESCRIPTION
For iOS 14+ apple changes regarding Application tracking, you need to ask the user for permission to track Application.

"isAdvertisingTrackingEnabled" is deprecated and always return NO/false for iOS 14+
https://developer.apple.com/documentation/adsupport/asidentifiermanager/1614148-isadvertisingtrackingenabled

